### PR TITLE
Fix code scanning alert no. 10: LDAP query built from user-controlled sources

### DIFF
--- a/src/main/java/com/kalavit/javulna/services/LdapService.java
+++ b/src/main/java/com/kalavit/javulna/services/LdapService.java
@@ -7,6 +7,7 @@ package com.kalavit.javulna.services;
 
 import com.kalavit.javulna.dto.LdapUserDto;
 import com.kalavit.javulna.springconfig.LdapConfig;
+import org.springframework.ldap.core.support.LdapEncoder;
 import java.util.Hashtable;
 import javax.naming.Context;
 import javax.naming.NamingEnumeration;
@@ -52,7 +53,9 @@ public class LdapService {
         try {
             LdapUserDto ret = new LdapUserDto();
             DirContext ctx = initContext();
-            String filter = "(&(uid=" + uid + ") (userPassword=" + password + "))";
+            String encodedUid = LdapEncoder.filterEncode(uid);
+            String encodedPassword = LdapEncoder.filterEncode(password);
+            String filter = "(&(uid=" + encodedUid + ") (userPassword=" + encodedPassword + "))";
 
             SearchControls ctls = new SearchControls();
             ctls.setSearchScope(SearchControls.SUBTREE_SCOPE);


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Java_2/security/code-scanning/10](https://github.com/digiALERT1/Java_2/security/code-scanning/10)

To fix the problem, we need to ensure that user input is properly encoded before being used in the LDAP query. This can be achieved by using an appropriate LDAP encoding method. In this case, we will use the `LdapEncoder.filterEncode` method from the Spring LDAP library to encode the user input before constructing the `filter` string.

1. Import the `LdapEncoder` class from the Spring LDAP library.
2. Encode the `uid` and `password` using `LdapEncoder.filterEncode`.
3. Use the encoded values to construct the `filter` string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
