### PR TITLE
Fix code scanning alert no. 6: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/com/kalavit/javulna/services/RemotePasswordChangeService.java
+++ b/src/main/java/com/kalavit/javulna/services/RemotePasswordChangeService.java
@@ -34,6 +34,9 @@ public class RemotePasswordChangeService {
     public boolean changePassword(String psChangeXml) {
         try {
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             DocumentBuilder db = dbf.newDocumentBuilder();
             Document doc = db.parse(new InputSource(new StringReader(psChangeXml)));
             String userName = doc.getElementsByTagName("userName").item(0).getFirstChild().getNodeValue();


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Java_2/security/code-scanning/6](https://github.com/digiALERT1/Java_2/security/code-scanning/6)

To fix the problem, we need to configure the `DocumentBuilderFactory` to disable the parsing of external entities and DTDs. This can be done by setting specific features on the `DocumentBuilderFactory` instance before creating the `DocumentBuilder`. This will ensure that the XML parser does not process any external entities, thus mitigating the risk of XXE attacks.

The changes should be made in the `changePassword` method of the `RemotePasswordChangeService` class. Specifically, we need to set the following features on the `DocumentBuilderFactory` instance:
- `http://apache.org/xml/features/disallow-doctype-decl` to `true`
- `http://xml.org/sax/features/external-general-entities` to `false`
- `http://xml.org/sax/features/external-parameter-entities` to `false`


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
