### PR TITLE
Fix code scanning alert no. 5: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/com/kalavit/javulna/services/MovieService.java
+++ b/src/main/java/com/kalavit/javulna/services/MovieService.java
@@ -91,7 +91,9 @@ public class MovieService {
     public Movie saveMovieFromXml(String xml){
         try {
             Movie m = new Movie();
-            DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            DocumentBuilder db = dbf.newDocumentBuilder();
             Document doc = db.parse(new ByteArrayInputStream(xml.getBytes("UTF-8")));
             Element root = doc.getDocumentElement();
             m.setTitle(getText(root, "title"));


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Java_2/security/code-scanning/5](https://github.com/digiALERT1/Java_2/security/code-scanning/5)

To fix the problem, we need to disable the parsing of Document Type Declarations (DTDs) in the `DocumentBuilderFactory` to prevent XXE attacks. This can be done by setting the appropriate features on the `DocumentBuilderFactory` instance before creating the `DocumentBuilder`. Specifically, we need to set the `http://apache.org/xml/features/disallow-doctype-decl` feature to `true`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
