### PR TITLE
Fix code scanning alert no. 9: Query built from user-controlled sources

### DIFF
--- a/src/main/java/com/kalavit/javulna/services/MovieService.java
+++ b/src/main/java/com/kalavit/javulna/services/MovieService.java
@@ -41,28 +41,18 @@ public class MovieService {
     MovieAutoDao movieAutoDao;
     
     public List<MovieDto> findMovie(String title, String description, String genre, String id) {
-        int conditions = 0;
-        StringBuilder sql = new StringBuilder("select description, title, genre, id from movie ");
+        StringBuilder sql = new StringBuilder("select description, title, genre, id from movie where 1=1");
         if (StringUtils.hasText(title)) {
-            appendCondition(sql, conditions);
-            conditions++;
-            sql.append("title LIKE '%").append(title).append("%'");
-
+            sql.append(" and title LIKE ?");
         }
         if (StringUtils.hasText(description)) {
-            appendCondition(sql, conditions);
-            conditions++;
-            sql.append("description LIKE '%").append(description).append("%'");
+            sql.append(" and description LIKE ?");
         }
         if (StringUtils.hasText(genre)) {
-            appendCondition(sql, conditions);
-            conditions++;
-            sql.append("genre LIKE '%").append(genre).append("%'");
+            sql.append(" and genre LIKE ?");
         }
         if (StringUtils.hasText(id)) {
-            appendCondition(sql, conditions);
-            conditions++;
-            sql.append("id = '").append(id).append("'");
+            sql.append(" and id = ?");
         }
         LOG.debug(sql.toString());
         List<MovieDto> users = this.jdbcTemplate.query(sql.toString(), new RowMapper<MovieDto>() {
@@ -75,7 +65,11 @@ public class MovieService {
                 ret.setId(rs.getString("id"));
                 return ret;
             }
-        });
+        }, 
+        StringUtils.hasText(title) ? "%" + title + "%" : null,
+        StringUtils.hasText(description) ? "%" + description + "%" : null,
+        StringUtils.hasText(genre) ? "%" + genre + "%" : null,
+        StringUtils.hasText(id) ? id : null);
 
         return users;
     }


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Java_2/security/code-scanning/9](https://github.com/digiALERT1/Java_2/security/code-scanning/9)

To fix the problem, we need to replace the string concatenation used to build the SQL query with a parameterized query. This involves using placeholders for the user-provided values and setting these values using the `setString` method of `PreparedStatement`. This approach ensures that the user input is properly escaped and prevents SQL injection attacks.

1. Modify the `findMovie` method in `MovieService` to use a `PreparedStatement` instead of string concatenation.
2. Replace the `StringBuilder` and `appendCondition` logic with a parameterized query.
3. Set the parameters for the query using the `setString` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
