### PR TITLE
Fix code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/src/main/java/com/kalavit/javulna/services/FileStorageService.java
+++ b/src/main/java/com/kalavit/javulna/services/FileStorageService.java
@@ -47,6 +47,10 @@ public class FileStorageService {
     }
     
     public Resource loadFileAsResource(String fileName) {
+        // Validate the fileName to ensure it does not contain any path separators or parent directory references
+        if (fileName.contains("..") || fileName.contains("/") || fileName.contains("\\")) {
+            throw new IllegalArgumentException("Invalid file name: " + fileName);
+        }
         try {
             Path filePath = Paths.get(fileStorageDir, fileName);
             LOG.debug("gonna read file from {}" ,filePath.toString());


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Java_2/security/code-scanning/4](https://github.com/digiALERT1/Java_2/security/code-scanning/4)

To fix the problem, we need to validate the `fileName` parameter before using it to construct a file path. We should ensure that the `fileName` does not contain any path separators or parent directory references. This can be done by checking for the presence of "..", "/", or "\\" in the `fileName` and throwing an exception if any are found.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
