### PR TITLE
Fix code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/src/main/java/com/kalavit/javulna/services/FileStorageService.java
+++ b/src/main/java/com/kalavit/javulna/services/FileStorageService.java
@@ -33,8 +33,14 @@ public class FileStorageService {
     @Value(value = "${javulna.filestore.dir}")
     private  String fileStorageDir;
 
+    private void validateFileName(String fileName) {
+        if (fileName.contains("..") || fileName.contains("/") || fileName.contains("\\")) {
+            throw new IllegalArgumentException("Invalid filename: " + fileName);
+        }
+    }
     public String storeFile(MultipartFile file) {
         String fileName = StringUtils.cleanPath(file.getOriginalFilename());
+        validateFileName(fileName);
         try {
             // Copy file to the target location (Replacing existing file with the same name)
             Path targetLocation = Paths.get(fileStorageDir, fileName);
@@ -47,6 +53,7 @@ public class FileStorageService {
     }
     
     public Resource loadFileAsResource(String fileName) {
+        validateFileName(fileName);
         try {
             Path filePath = Paths.get(fileStorageDir, fileName);
             LOG.debug("gonna read file from {}" ,filePath.toString());


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Java_2/security/code-scanning/3](https://github.com/digiALERT1/Java_2/security/code-scanning/3)

To fix the problem, we need to validate the filename to ensure it does not contain any path separators or parent directory references. This can be done by checking for the presence of "..", "/", or "\\" in the filename and throwing an exception if any are found. Additionally, we should ensure that the resolved path is still within the intended directory.

1. In the `storeFile` method, validate the filename before constructing the file path.
2. In the `loadFileAsResource` method, validate the filename before constructing the file path.
3. Add a helper method to perform the validation to avoid code duplication.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
